### PR TITLE
Fixes for Intel IOMMU

### DIFF
--- a/firegl_public.c
+++ b/firegl_public.c
@@ -93,7 +93,7 @@
    and they use different config options. These options can only be enabled
    on x86_64 with newer 2.6 kernels (2.6.23 for intel, 2.6.26 for amd). 
 */
-#if defined(CONFIG_AMD_IOMMU) || defined(CONFIG_DMAR)
+#if defined(CONFIG_AMD_IOMMU) || defined(CONFIG_INTEL_IOMMU) || defined(CONFIG_DMAR)
     #define FIREGL_DMA_REMAPPING
 #endif
 


### PR DESCRIPTION
I used your modifications to the fglrx kernel module which worked well with Linux 3.19.

Yesterday I enabled Intel IOMMU because I wanted to test PCI passthrough in kvm. When X11 was started, it hung on a black screen with a solid, non blinking cursor.

In kcl_iommu.c I noticed following comment:

// CONFIG_DMAR is before KERNEL_VERSION(3,1,0); CONFIG_INTEL_IOMMU is including and after.

I added CONFIG_INTEL_IOMMU to the firegl_public.c and at the first glance everything works well again.

Maybe you want to include this into your repository
